### PR TITLE
make unit for --hours dynamic based on max

### DIFF
--- a/src/dbshow.c
+++ b/src/dbshow.c
@@ -877,7 +877,7 @@ void showhours(void)
 
 	/* determine unit to use for output */
 	i=1;
-	while (max / div > 9999)
+	while (max / div > 99999)
 	{
 		i++;
 		div=div*1024;


### PR DESCRIPTION
showhours - when max>9999 (we like large numbers) move to next unit.
this means we no longer output in KiB exclusively

fixes #4
