### PR TITLE
make the path to vnstat.conf variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,13 @@
 BIN ?= $(DESTDIR)/usr/bin
 SBIN ?= $(DESTDIR)/usr/sbin
 MAN ?= $(DESTDIR)/usr/share/man
+ETC ?= $(DESTDIR)/etc/
 
 # bin and man dirs for *BSD
 BIN_BSD ?= $(DESTDIR)/usr/local/bin
 SBIN_BSD ?= $(DESTDIR)/usr/local/sbin
 MAN_BSD ?= $(DESTDIR)/usr/local/man
+ETC_BSD ?= $(DESTDIR)/etc
 
 .PHONY: vnstat tests check all clean debug install uninstall bsdinstall bsduninstall dist
 
@@ -58,10 +60,10 @@ install:
 	fi
 
 # install default config if such doesn't exist
-	@if [ ! -f "$(DESTDIR)/etc/vnstat.conf" ]; \
-	then echo "Installing config to $(DESTDIR)/etc/vnstat.conf"; \
-	install -d -m 755 $(DESTDIR)/etc; \
-	install -m 644 cfg/vnstat.conf $(DESTDIR)/etc/vnstat.conf; \
+	@if [ ! -f "$(ETC)/vnstat.conf" ]; \
+	then echo "Installing config to $(ETC)/vnstat.conf"; \
+	install -d -m 755 $(ETC); \
+	install -m 644 cfg/vnstat.conf $(ETC)/vnstat.conf; \
 	fi
 
 # install everything else
@@ -118,7 +120,7 @@ uninstall:
 	rm -f $(MAN)/man1/vnstat*
 	rm -f $(MAN)/man5/vnstat*
 	rm -f $(DESTDIR)/etc/cron.d/vnstat
-	rm -f $(DESTDIR)/etc/vnstat.conf
+	rm -f $(ETC)/vnstat.conf
 	rm -f $(DESTDIR)/etc/ppp/ip-up.d/vnstat
 	rm -f $(DESTDIR)/etc/ppp/ip-down.d/vnstat
 
@@ -148,12 +150,12 @@ bsdinstall:
 	fi
 
 # install default config if such doesn't exist
-	@if [ ! -f "$(DESTDIR)/etc/vnstat.conf" ]; \
-	then echo "Installing config to $(DESTDIR)/etc/vnstat.conf"; \
-	install -d -m 755 $(DESTDIR)/etc; \
-	install -m 644 cfg/vnstat.conf $(DESTDIR)/etc/vnstat.conf; \
-	sed -e 's/lib/db/g' $(DESTDIR)/etc/vnstat.conf >$(DESTDIR)/etc/vnstat.conf.bsd; \
-	mv -f $(DESTDIR)/etc/vnstat.conf.bsd $(DESTDIR)/etc/vnstat.conf; \
+	@if [ ! -f "$(ETC_BSD)/vnstat.conf" ]; \
+	then echo "Installing config to $(ETC_BSD)/vnstat.conf"; \
+	install -d -m 755 $(ETC_BSD); \
+	install -m 644 cfg/vnstat.conf $(ETC_BSD)/vnstat.conf; \
+	sed -e 's/lib/db/g' $(ETC_BSD)/vnstat.conf >$(ETC_BSD)/vnstat.conf.bsd; \
+	mv -f $(ETC_BSD)/vnstat.conf.bsd $(ETC_BSD)/vnstat.conf; \
 	fi
 
 # update man page	
@@ -196,7 +198,7 @@ bsduninstall:
 	rm -f $(SBIN_BSD)/vnstatd
 	rm -f $(MAN_BSD)/man1/vnstat*
 	rm -f $(MAN_BSD)/man5/vnstat*
-	rm -f $(DESTDIR)/etc/vnstat.conf
+	rm -f $(ETC_BSD)/vnstat.conf
 	@echo "A possible cron entry needs to be removed manually if such exists."
 
 dist: clean


### PR DESCRIPTION
On OpenBSD we install the `vnstat.conf` into `/usr/local/share/examples/vnstat/` so we don't unconditionally overwrite `/etc/vnstat.conf`