### PR TITLE
Fix JSON output for new databases

### DIFF
--- a/src/dbjson.c
+++ b/src/dbjson.c
@@ -4,6 +4,7 @@
 void showjson(int dbcount)
 {
 	int i;
+	int first;
 
 	if (dbcount) {
 		printf(",");
@@ -23,53 +24,57 @@ void showjson(int dbcount)
 	printf("{\"total\":{\"rx\":%"PRIu64",\"tx\":%"PRIu64"},", (data.totalrx*1024)+data.totalrxk, (data.totaltx*1024)+data.totaltxk);
 
 	printf("\"days\":[");
-	for (i=0;i<=29;i++) {
+	for (i=0, first=1;i<=29;i++) {
 		if (data.day[i].used) {
-			if (i>0) {
+			if (!first) {
 				printf(",");
 			}
 			printf("{\"id\":%d,", i);
 			jsondate(&data.day[i].date, 1);
 			printf(",\"rx\":%"PRIu64",\"tx\":%"PRIu64"}", (data.day[i].rx*1024)+data.day[i].rxk, (data.day[i].tx*1024)+data.day[i].txk);
+			first = 0;
 		}
 	}
 	printf("],");
 
 	printf("\"months\":[");
-	for (i=0;i<=11;i++) {
+	for (i=0, first=1;i<=11;i++) {
 		if (data.month[i].used) {
-			if (i>0) {
+			if (!first) {
 				printf(",");
 			}
 			printf("{\"id\":%d,", i);
 			jsondate(&data.month[i].month, 3);
 			printf(",\"rx\":%"PRIu64",\"tx\":%"PRIu64"}", (data.month[i].rx*1024)+data.month[i].rxk, (data.month[i].tx*1024)+data.month[i].txk);
+			first = 0;
 		}
 	}
 	printf("],");
 
 	printf("\"tops\":[");
-	for (i=0;i<=9;i++) {
+	for (i=0, first=1;i<=9;i++) {
 		if (data.top10[i].used) {
-			if (i>0) {
+			if (!first) {
 				printf(",");
 			}
 			printf("{\"id\":%d,", i);
 			jsondate(&data.top10[i].date, 2);
 			printf(",\"rx\":%"PRIu64",\"tx\":%"PRIu64"}", (data.top10[i].rx*1024)+data.top10[i].rxk, (data.top10[i].tx*1024)+data.top10[i].txk);
+			first = 0;
 		}
 	}
 	printf("],");
 
 	printf("\"hours\":[");
-	for (i=0;i<=23;i++) {
+	for (i=0, first=1;i<=23;i++) {
 		if (data.hour[i].date!=0) {
-			if (i>0) {
+			if (!first) {
 				printf(",");
 			}
 			printf("{\"id\":%d,", i);
 			jsondate(&data.hour[i].date, 1);
 			printf(",\"rx\":%"PRIu64",\"tx\":%"PRIu64"}", data.hour[i].rx, data.hour[i].tx);
+			first = 0;
 		}
 	}
 	printf("]}}");


### PR DESCRIPTION
Just installed vnstat from the ArchLinux repository and did `$ vnstat --json|json_pp` shortly after starting the daemon. json_pp notified me of bad JSON data. Output as generated by vnstat --json (Removed irrelevant parts):
````
{"interfaces":[{"traffic":{"hours":[,{"id":19,"date":{"year":2015,"month":1,"day":28},"rx":7876,"tx":428}]}}]}
````
The 'hours' array begins with a comma (","), yielding illegal JSON data. The attached patch fixes all of these cases in dbjson.c.