### PR TITLE
fix typo in --create duplication error message

### DIFF
--- a/src/vnstat.c
+++ b/src/vnstat.c
@@ -733,7 +733,7 @@ void handlecreate(PARAMS *p)
 	}
 
 	if (checkdb(p->interface, p->dirname)) {
-		printf("Error: Database for interface \"%s\" already exists.\n", data.interface);
+		printf("Error: Database for interface \"%s\" already exists.\n", p->interface);
 		exit(EXIT_FAILURE);
 	}
 


### PR DESCRIPTION
fixes:
````
# vnstat -i eth0 --create
Error: Database for interface "" already exists.
```