### PR TITLE
Removed manual setting of date to the first of the month

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -163,9 +163,6 @@ uint32_t mosecs(void)
 		return 0;
 	}
 
-	d->tm_mday = cfg.monthrotate;
-	d->tm_hour = d->tm_min = d->tm_sec = 0;
-
 	if ((data.lastupdated-data.month[0].month)>0) {
 		return data.lastupdated-mktime(d);
 	} else {


### PR DESCRIPTION
This setting seemed unnecessary and was causing issues for people in GMT+ timezones. Current month data was displaying as the previous month due to me being in GMT+11.

Issue only occurred when showing estimated data usage (didn't appear when using "--style 0")