### PR TITLE
On daemon startup, create databases for all available interfaces

### DIFF
--- a/man/vnstatd.1
+++ b/man/vnstatd.1
@@ -65,7 +65,7 @@ Once started, the daemon will read
 if available and then check if there are any databases available
 in the database directory that has been specified in the configuration
 file. New databases will be created for all available interfaces excluding
-pseudo interfaces lo, lo0 and sit0 if no databases are found during startup.
+pseudo interfaces lo, lo0 and sit0 during startup.
 This behaviour can be disabled if needed. The daemon will then
 proceed to track the availability of monitored interfaces, process the
 interface traffic statistics and write new values to databases


### PR DESCRIPTION
If any databases exist when the daemon starts, no new interfaces were added.

This commit will change the daemon's behavior so that (unless --no-add is set) any new available interfaces get added to the databases directory on startup, regardless of whether any database files exist.