### PR TITLE
configure.ac: add option to disable image output

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -180,6 +180,61 @@ else
 fi[]dnl
 ])# PKG_CHECK_MODULES
 
+
+# PKG_INSTALLDIR(DIRECTORY)
+# -------------------------
+# Substitutes the variable pkgconfigdir as the location where a module
+# should install pkg-config .pc files. By default the directory is
+# $libdir/pkgconfig, but the default can be changed by passing
+# DIRECTORY. The user can override through the --with-pkgconfigdir
+# parameter.
+AC_DEFUN([PKG_INSTALLDIR],
+[m4_pushdef([pkg_default], [m4_default([$1], ['${libdir}/pkgconfig'])])
+m4_pushdef([pkg_description],
+    [pkg-config installation directory @<:@]pkg_default[@:>@])
+AC_ARG_WITH([pkgconfigdir],
+    [AS_HELP_STRING([--with-pkgconfigdir], pkg_description)],,
+    [with_pkgconfigdir=]pkg_default)
+AC_SUBST([pkgconfigdir], [$with_pkgconfigdir])
+m4_popdef([pkg_default])
+m4_popdef([pkg_description])
+]) dnl PKG_INSTALLDIR
+
+
+# PKG_NOARCH_INSTALLDIR(DIRECTORY)
+# -------------------------
+# Substitutes the variable noarch_pkgconfigdir as the location where a
+# module should install arch-independent pkg-config .pc files. By
+# default the directory is $datadir/pkgconfig, but the default can be
+# changed by passing DIRECTORY. The user can override through the
+# --with-noarch-pkgconfigdir parameter.
+AC_DEFUN([PKG_NOARCH_INSTALLDIR],
+[m4_pushdef([pkg_default], [m4_default([$1], ['${datadir}/pkgconfig'])])
+m4_pushdef([pkg_description],
+    [pkg-config arch-independent installation directory @<:@]pkg_default[@:>@])
+AC_ARG_WITH([noarch-pkgconfigdir],
+    [AS_HELP_STRING([--with-noarch-pkgconfigdir], pkg_description)],,
+    [with_noarch_pkgconfigdir=]pkg_default)
+AC_SUBST([noarch_pkgconfigdir], [$with_noarch_pkgconfigdir])
+m4_popdef([pkg_default])
+m4_popdef([pkg_description])
+]) dnl PKG_NOARCH_INSTALLDIR
+
+
+# PKG_CHECK_VAR(VARIABLE, MODULE, CONFIG-VARIABLE,
+# [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND])
+# -------------------------------------------
+# Retrieves the value of the pkg-config variable for the given module.
+AC_DEFUN([PKG_CHECK_VAR],
+[AC_REQUIRE([PKG_PROG_PKG_CONFIG])dnl
+AC_ARG_VAR([$1], [value of $3 for $2, overriding pkg-config])dnl
+
+_PKG_CONFIG([$1], [variable="][$3]["], [$2])
+AS_VAR_COPY([$1], [pkg_cv_][$1])
+
+AS_VAR_IF([$1], [""], [$5], [$4])dnl
+])# PKG_CHECK_VAR
+
 # Copyright (C) 2002-2013 Free Software Foundation, Inc.
 #
 # This file is free software; the Free Software Foundation
@@ -263,10 +318,9 @@ _AM_AUTOCONF_VERSION(m4_defn([AC_AUTOCONF_VERSION]))])
 # configured tree to be moved without reconfiguration.
 
 AC_DEFUN([AM_AUX_DIR_EXPAND],
-[dnl Rely on autoconf to set up CDPATH properly.
-AC_PREREQ([2.50])dnl
-# expand $ac_aux_dir to an absolute path
-am_aux_dir=`cd $ac_aux_dir && pwd`
+[AC_REQUIRE([AC_CONFIG_AUX_DIR_DEFAULT])dnl
+# Expand $ac_aux_dir to an absolute path.
+am_aux_dir=`cd "$ac_aux_dir" && pwd`
 ])
 
 # AM_COND_IF                                            -*- Autoconf -*-
@@ -770,7 +824,8 @@ to "yes", and re-run configure.
 END
     AC_MSG_ERROR([Your 'rm' program is bad, sorry.])
   fi
-fi])
+fi
+])
 
 dnl Hook into '_AC_COMPILER_EXEEXT' early to learn its expansion.  Do not
 dnl add the conditional right here, as _AC_COMPILER_EXEEXT may be further

--- a/configure
+++ b/configure
@@ -729,6 +729,7 @@ enable_option_checking
 enable_silent_rules
 enable_maintainer_mode
 enable_dependency_tracking
+enable_image_output
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1367,6 +1368,8 @@ Optional Features:
                           do not reject slow dependency extractors
   --disable-dependency-tracking
                           speeds up one-time build
+
+  --disable-image-output  disable PNG image output
 
 Some influential environment variables:
   CC          C compiler command
@@ -2553,8 +2556,8 @@ test "$program_suffix" != NONE &&
 ac_script='s/[\\$]/&&/g;s/;s,x,x,$//'
 program_transform_name=`$as_echo "$program_transform_name" | sed "$ac_script"`
 
-# expand $ac_aux_dir to an absolute path
-am_aux_dir=`cd $ac_aux_dir && pwd`
+# Expand $ac_aux_dir to an absolute path.
+am_aux_dir=`cd "$ac_aux_dir" && pwd`
 
 if test x"${MISSING+set}" != xset; then
   case $am_aux_dir in
@@ -2959,6 +2962,7 @@ END
     as_fn_error $? "Your 'rm' program is bad, sorry." "$LINENO" 5
   fi
 fi
+
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to enable maintainer-specific portions of Makefiles" >&5
 $as_echo_n "checking whether to enable maintainer-specific portions of Makefiles... " >&6; }
@@ -4061,6 +4065,12 @@ fi
 
 
 
+# Check whether --enable-image-output was given.
+if test "${enable_image_output+set}" = set; then :
+  enableval=$enable_image_output;
+fi
+
+
 # Checks for libraries.
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for pow in -lm" >&5
@@ -4108,9 +4118,12 @@ _ACEOF
 
 fi
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for gdImageLine in -lgd" >&5
-$as_echo_n "checking for gdImageLine in -lgd... " >&6; }
-if ${ac_cv_lib_gd_gdImageLine+:} false; then :
+
+if test "x$enable_image_output" != "xno"; then :
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for gdImagePng in -lgd" >&5
+$as_echo_n "checking for gdImagePng in -lgd... " >&6; }
+if ${ac_cv_lib_gd_gdImagePng+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
@@ -4124,30 +4137,32 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 #ifdef __cplusplus
 extern "C"
 #endif
-char gdImageLine ();
+char gdImagePng ();
 int
 main ()
 {
-return gdImageLine ();
+return gdImagePng ();
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_gd_gdImageLine=yes
+  ac_cv_lib_gd_gdImagePng=yes
 else
-  ac_cv_lib_gd_gdImageLine=no
+  ac_cv_lib_gd_gdImagePng=no
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 LIBS=$ac_check_lib_save_LIBS
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_gd_gdImageLine" >&5
-$as_echo "$ac_cv_lib_gd_gdImageLine" >&6; }
-if test "x$ac_cv_lib_gd_gdImageLine" = xyes; then :
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_gd_gdImagePng" >&5
+$as_echo "$ac_cv_lib_gd_gdImagePng" >&6; }
+if test "x$ac_cv_lib_gd_gdImagePng" = xyes; then :
   IMAGELIBS=-lgd
 fi
 
+
+fi
 
  if test "$IMAGELIBS" = "-lgd"; then
   HAVE_LIBGD_TRUE=

--- a/configure.ac
+++ b/configure.ac
@@ -13,10 +13,16 @@ AM_PROG_CC_C_O
 AC_PROG_MAKE_SET
 AC_PROG_MKDIR_P
 
+AC_ARG_ENABLE([image-output], [
+AS_HELP_STRING([--disable-image-output], [disable PNG image output])])
+
 # Checks for libraries.
 AC_CHECK_LIB([m], [pow])
-AC_CHECK_LIB([gd], [gdImageLine], [IMAGELIBS=-lgd])
-AC_SUBST([IMAGELIBS])
+
+AS_IF([test "x$enable_image_output" != "xno"], [
+AC_CHECK_LIB([gd], [gdImagePng], [IMAGELIBS=-lgd])
+AC_SUBST([IMAGELIBS])])
+
 AM_CONDITIONAL([HAVE_LIBGD], [test "$IMAGELIBS" = "-lgd"])
 PKG_CHECK_MODULES([CHECK], [check >= 0.9.6], [], [AC_MSG_NOTICE([testcases can not be execute without check installed])])
 AM_CONDITIONAL([HAVE_CHECK], [test "$CHECK_LIBS"])


### PR DESCRIPTION
Even when the gd library is present, it may be desirable to not build
'vnstati' as image output is an optional feature.

Also, when testing for the gd library, use gdImagePng() instead of
gdImageLine() since it's possible that the installed gd library doesn't
have PNG support. In such cases, the test in the configure script passed
(because gdImageLine() is always present), but the build failed with:

  src/vnstati.o: In function 'writeoutput':
  vnstati.c:(.text+0x3fc): undefined reference to 'gdImagePng'
  collect2: error: ld returned 1 exit status