### PR TITLE
Makefile.am: install-data-hook depends on install-exec

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -103,7 +103,7 @@ release: distcheck
 	rm -fr $(PACKAGE_NAME)-$(PACKAGE_VERSION)
 	ls -l $(PACKAGE_NAME)-$(PACKAGE_VERSION).tar.gz
 
-install-data-hook:
+install-data-hook: install-exec
 	$(MKDIR_P) $(DESTDIR)$(sysconfdir)
 if IS_CROSSCOMPILED
 	if [ ! -f $(DESTDIR)$(sysconfdir)/vnstat.conf ]; \


### PR DESCRIPTION
Forwarded from https://bugs.debian.org/859712

Calling $(DESTDIR)$(bindir)/vnstat$(EXEEXT) fails when installation of this
program is not yet finished.

Author: Adrian Bunk <bunk@debian.org>