### PR TITLE
fix several warnings from tools

### DIFF
--- a/src/cfg.c
+++ b/src/cfg.c
@@ -63,7 +63,7 @@ void printcfgfile(void)
 	printf("#MaxBWeth0 8\n");
 
 	while (p != NULL) {
-		printf("MaxBW%s %d\n", p->interface, p->limit);
+		printf("MaxBW%s %u\n", p->interface, p->limit);
 		p = p->next;
 	}
 

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -173,7 +173,7 @@ int addinterfaces(const char *dirname, const int running)
 			}
 		} else {
 			if (debug)
-				printf("\%s\" added with %"PRIu32" Mbit bandwidth limit to cache.\n", interface, bwlimit);
+				printf("\"%s\" added with %"PRIu32" Mbit bandwidth limit to cache.\n", interface, bwlimit);
 			cacheadd(interface, 1);
 		}
 	}

--- a/src/dbcache.c
+++ b/src/dbcache.c
@@ -330,19 +330,19 @@ uint32_t dbcheck(uint32_t dbhash, int *forcesave)
 	return newhash;
 }
 
-uint32_t simplehash(const char *data, int len)
+uint32_t simplehash(const char *input, int len)
 {
 	uint32_t hash = len;
 
-	if (len <= 0 || data == NULL) {
+	if (len <= 0 || input == NULL) {
 		return 0;
 	}
 
 	for (len--; len >= 0; len--) {
 		if (len > 0) {
-			hash += (int)data[len] * len;
+			hash += (int)input[len] * len;
 		} else {
-			hash += (int)data[len];
+			hash += (int)input[len];
 		}
 	}
 

--- a/src/dbcache.h
+++ b/src/dbcache.h
@@ -18,7 +18,7 @@ void cacheflush(const char *dirname);
 int cachecount(void);
 int cacheactivecount(void);
 uint32_t dbcheck(uint32_t dbhash, int *forcesave);
-uint32_t simplehash(const char *data, int len);
+uint32_t simplehash(const char *input, int len);
 
 /* global variables */
 datanode *dataptr;

--- a/src/fs.c
+++ b/src/fs.c
@@ -84,25 +84,25 @@ int mkpath(const char *dir, const mode_t mode)
 	return ret;
 }
 
-void preparevnstatdir(const char *file, const char *user, const char *group)
+void preparevnstatdir(const char *dir, const char *user, const char *group)
 {
 	int len, i, lastslash=0;
 	char *path, *base;
 
-	if (file == NULL) {
+	if (dir == NULL) {
 		return;
 	}
 
-	len = strlen(file);
+	len = strlen(dir);
 	if (len<2) {
 		return;
 	}
 
-	if (file[len-1] == '/') {
+	if (dir[len-1] == '/') {
 		return;
 	}
 
-	path = strdup(file);
+	path = strdup(dir);
 	if (path == NULL) {
 		return;
 	}
@@ -115,7 +115,7 @@ void preparevnstatdir(const char *file, const char *user, const char *group)
 	}
 	free(path);
 
-	path = strdup(file);
+	path = strdup(dir);
 	if (path == NULL) {
 		return;
 	}

--- a/src/image.h
+++ b/src/image.h
@@ -9,7 +9,7 @@
 #include <gdfontg.h>   /* gdFontGetGiant() */
 
 /* rectangle size */
-#define YBEGINOFFSET -1
+#define YBEGINOFFSET (-1)
 #define YENDOFFSET 6
 
 /* donut size */

--- a/src/misc.h
+++ b/src/misc.h
@@ -5,7 +5,7 @@
 
 int kerneltest(void);
 int spacecheck(char *path);
-void sighandler(int);
+void sighandler(int sig);
 uint64_t getbtime(void);
 char *getvalue(uint64_t mb, uint64_t kb, int len, int type);
 char *getrate(uint64_t mb, uint64_t kb, uint32_t interval, int len);


### PR DESCRIPTION
* fix printf argument
  found by cppcheck:
  [src/cfg.c:66]: (warning) %d in format string (no. 2) requires 'int' but the argument type is 'unsigned int'.

* fix clang-tidy issues
  src/image.h:12:22: warning: macro replacement list should be enclosed in parentheses [misc-macro-parentheses]
  src/misc.h:8:20: warning: all parameters should be named in a function [readability-named-parameter]
  src/fs.h:7:6: warning: function 'preparevnstatdir' has a definition with different parameter names [readability-inconsistent-declaration-parameter-name]

* fix compile warnings
  src/daemon.c:176:13: warning: use of non-standard escape character '\%' [-Wpedantic]
  src/dbcache.c:333:33: warning: declaration shadows a variable in the global scope [-Wshadow]