### PR TITLE
Added "Restart=on-failure" because vnstat is not able to start on (embedded) machines without a RTC. 

### DIFF
--- a/examples/systemd/vnstat.service
+++ b/examples/systemd/vnstat.service
@@ -6,6 +6,8 @@ After=network.target
 [Service]
 ExecStart=/usr/sbin/vnstatd -n
 ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+RestartSec=10
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
On these machines it will error out with
"Interface "XXXX" has previous update date too much in the future, ..."
After NTP has corrected the time, if should restart.