### PR TITLE
fix cppcheck note

### DIFF
--- a/src/dbcache.c
+++ b/src/dbcache.c
@@ -163,7 +163,7 @@ void cachestatus(void)
 			if (!ibwget(p->data.interface, &bwlimit) || bwlimit == 0) {
 				snprintf(bwtemp, 16, " (no limit) ");
 			} else {
-				snprintf(bwtemp, 16, " (%d Mbit) ", bwlimit);
+				snprintf(bwtemp, 16, " (%u Mbit) ", bwlimit);
 			}
 			strncat(buffer, p->data.interface, strlen(p->data.interface));
 			strncat(buffer, bwtemp, strlen(bwtemp));


### PR DESCRIPTION
[src/dbcache.c:166]: (warning) %d in format string (no. 1) requires 'int' but the argument type is 'unsigned int'.