### PR TITLE
Remove --delete option from manpage

### DIFF
--- a/man/vnstat.1
+++ b/man/vnstat.1
@@ -14,7 +14,6 @@ vnstat \- a console-based network traffic monitor
 .RB [ \-\-create ]
 .RB [ \-\-days
 .RI [ count ]]
-.RB [ \-\-delete ]
 .RB [ \-\-dbdir
 .RI [ directory ]]
 .RB [ \-\-debug ]


### PR DESCRIPTION
Hi, I just noticed that leftover --delete in the man.