### PR TITLE
man/vnstat.1: fix typo today with current month

### DIFF
--- a/man/vnstat.1
+++ b/man/vnstat.1
@@ -257,7 +257,7 @@ in future versions of vnStat if the field structure changes. The following
 fields in order 2) interface name, 3) timestamp for today, 4) rx for today,
 5) tx for today, 6) total for today, 7) average traffic rate for today,
 8) timestamp for current month, 9) rx for current month, 10) tx for current
-month, 11) total for current month, 12) average traffic rate for today,
+month, 11) total for current month, 12) average traffic rate for current month,
 13) all time total rx, 14) all time total tx, 15) all time total traffic.
 An optional
 .I mode


### PR DESCRIPTION
Fix typo `today` with `current month`
```
--oneline
       Show  traffic  summary  for  selected  interface  using one line with a
       parseable format. The output contains 15 fields with ;  used  as  field
       delimiter. The 1st field contains the version information of the output
       that will be changed in future versions of vnStat if the  field  struc‐
       ture changes. The following fields in order 2) interface name, 3) time‐
       stamp for today, 4) rx for today, 5) tx for today, 6) total for  today,
       7)  average  traffic rate for today, 8) timestamp for current month, 9)
       rx for current month, 10) tx for current month, 11) total  for  current
       month,  12)  average traffic rate for today, 13) all time total rx, 14)
       all time total tx, 15) all time total traffic.  An optional mode param‐
       eter  can  be  used  to force all fields to output in bytes without the
       unit itself shown.
```