### PR TITLE
enable Ubuntu Xenial in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,18 @@ matrix:
       env:
         - CFLAGS='-Weverything -Wno-padded'
         - CPARAMS='--enable-werror'
+    - os: linux
+      dist: xenial
+      compiler: gcc
+      env:
+        - CFLAGS='-Wall -Wextra'
+        - CPARAMS='--enable-werror'
+    - os: linux
+      dist: xenial
+      compiler: clang
+      env:
+        - CFLAGS='-Weverything -Wno-padded'
+        - CPARAMS='--enable-werror'
     - os: osx
       compiler: clang
       env:


### PR DESCRIPTION
Previously only Trusty was available. Xenial was announced today: https://blog.travis-ci.com/2018-11-08-xenial-release