### PR TITLE
fix Coverity findings

### DIFF
--- a/src/dbsql.c
+++ b/src/dbsql.c
@@ -1171,11 +1171,6 @@ int db_getdata_range(dbdatalist **dbdata, dbdatalistinfo *listinfo, const char *
 
 	listinfo->count = 0;
 
-	ifaceidin = db_getinterfaceidin(iface);
-	if (ifaceidin == NULL) {
-		return 0;
-	}
-
 	ret = 0;
 	for (i = 0; i < 6; i++) {
 		if (strcmp(table, datatables[i]) == 0) {
@@ -1184,6 +1179,11 @@ int db_getdata_range(dbdatalist **dbdata, dbdatalistinfo *listinfo, const char *
 		}
 	}
 	if (!ret) {
+		return 0;
+	}
+
+	ifaceidin = db_getinterfaceidin(iface);
+	if (ifaceidin == NULL) {
 		return 0;
 	}
 

--- a/src/dbsql.c
+++ b/src/dbsql.c
@@ -616,6 +616,7 @@ int db_getinterfaceinfo(const char *iface, interfaceinfo *info)
 	} else {
 		ifaceidin = db_getinterfaceidin(iface);
 		if (ifaceidin == NULL || strlen(ifaceidin) < 1) {
+			free(ifaceidin);
 			return 0;
 		}
 		sqlite3_snprintf(512, sql, "select \"%q\", NULL, max(active), max(strftime('%%s', created, 'utc')), min(strftime('%%s', updated, 'utc')), 0, 0, sum(rxtotal), sum(txtotal) from interface where id in (%q)", iface, ifaceidin);

--- a/src/fs.c
+++ b/src/fs.c
@@ -229,7 +229,6 @@ void updatedirownerid(const char *dir, const uid_t uid, const gid_t gid)
 	}
 
 	closedir(d);
-	close(dir_fd);
 }
 
 int getdirowner(const char *dir, uid_t *uid, gid_t *gid)


### PR DESCRIPTION
*  fix resource leak in db_getdata_range
   if an invalid 'table' is given the function returns without freeing 'ifaceidin'
    postpone the initialization
*  fix resource leak in db_getinterfaceinfo
   if 'ifaceidin' gets initialized but it's length is 0, it is not freed
*  fix double close in updatedirownerid
   after successfully passing 'dir_fd' to 'fdopendir' is must not be closed manually
