### PR TITLE
run testsuite with sanitizers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,13 @@ matrix:
       env:
         - CFLAGS='-Weverything -Wno-padded'
         - CPARAMS='--enable-werror'
+    - name: "Ubuntu 18.04 / Clang + Sanitizers"
+      os: linux
+      dist: bionic
+      compiler: clang
+      env:
+        - CFLAGS='-O1 -g -fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined -fsanitize=nullability -fsanitize=implicit-conversion -fsanitize=integer'
+        - CPARAMS='--enable-werror'
     - name: "OS X / Clang"
       os: osx
       compiler: clang
@@ -54,7 +61,7 @@ before_install:
  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew install gd sqlite check ; fi
 
 script:
- - ./configure ${CPARAMS} && make check || ( cat test.log ; exit 1 ) && egrep '^[0-9]+%' test.log && ./vnstat --version
+ - ./configure ${CPARAMS} && make check || ( cat test.log ; cat test-suite.log ; exit 1 ) && egrep '^[0-9]+%' test.log && ./vnstat --version
 
 notifications:
   email:

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -268,6 +268,15 @@ void initdstate(DSTATE *s)
 	s->prevwaldbcheckpoint = time(NULL);
 }
 
+#ifdef CHECK_VNSTAT
+void destroystate(DSTATE *s)
+{
+	if (s->dcache) {
+		datacache_clear(&s->dcache);
+	}
+}
+#endif
+
 void preparedatabase(DSTATE *s)
 {
 	s->dbifcount = db_getinterfacecount();

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -19,6 +19,9 @@ void debugtimestamp(void);
 
 unsigned int addinterfaces(DSTATE *s);
 void initdstate(DSTATE *s);
+#ifdef CHECK_VNSTAT
+void destroystate(DSTATE *s);
+#endif
 void preparedatabase(DSTATE *s);
 unsigned int importlegacydbs(DSTATE *s);
 void setsignaltraps(void);

--- a/src/dbsql.c
+++ b/src/dbsql.c
@@ -1347,7 +1347,7 @@ unsigned int getqueryinterfacecount(const char *input)
 {
 	unsigned int i, ifacecount = 1;
 
-	if (input[0] == '+' || input[strlen(input) - 1] == '+' || !strlen(input)) {
+	if (!strlen(input) || input[0] == '+' || input[strlen(input) - 1] == '+') {
 		return 0;
 	}
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -192,7 +192,7 @@ int getunitspacing(const int len, const int index)
 
 	/* tune spacing according to unit */
 	/* +1 for space between number and unit */
-	l -= strlen(getunitprefix(index)) + 1;
+	l -= (int) strlen(getunitprefix(index)) + 1;
 	if (l < 0) {
 		l = 1;
 	}
@@ -309,7 +309,7 @@ int getratespacing(const int len, const int unitmode, const int unitindex)
 {
 	int l = len;
 
-	l -= strlen(getrateunitprefix(unitmode, unitindex)) + 1;
+	l -= (int) strlen(getrateunitprefix(unitmode, unitindex)) + 1;
 	if (l < 0) {
 		l = 1;
 	}

--- a/tests/daemon_tests.c
+++ b/tests/daemon_tests.c
@@ -188,6 +188,8 @@ START_TEST(addinterfaces_adds_to_cache_when_running)
 
 	ret = db_close();
 	ck_assert_int_eq(ret, 1);
+
+	destroystate(&s);
 }
 END_TEST
 
@@ -350,6 +352,8 @@ START_TEST(filldatabaselist_adds_databases)
 	ck_assert_int_eq(intsignal, 42);
 	ret = db_close();
 	ck_assert_int_eq(ret, 1);
+
+	destroystate(&s);
 }
 END_TEST
 
@@ -382,6 +386,8 @@ START_TEST(adjustsaveinterval_with_filled_cache)
 	adjustsaveinterval(&s);
 
 	ck_assert_int_eq(s.saveinterval, cfg.saveinterval * 60);
+
+	destroystate(&s);
 }
 END_TEST
 
@@ -490,6 +496,8 @@ START_TEST(processdatacache_can_process_things)
 
 	ret = db_close();
 	ck_assert_int_eq(ret, 1);
+
+	destroystate(&s);
 }
 END_TEST
 
@@ -710,6 +718,8 @@ START_TEST(interfacechangecheck_with_no_changes_in_iflist)
 	interfacechangecheck(&s);
 	ck_assert_int_eq(s.iflisthash, ifhash);
 	ck_assert_int_eq(s.forcesave, 0);
+
+        free(ifacelist);
 }
 END_TEST
 
@@ -748,6 +758,8 @@ START_TEST(interfacechangecheck_with_filled_cache)
 	ck_assert_int_eq(s.forcesave, 1);
 	ck_assert_int_eq(datacache_count(&s.dcache), 2);
 	ck_assert_int_eq(datacache_activecount(&s.dcache), 1);
+
+	destroystate(&s);
 }
 END_TEST
 
@@ -780,6 +792,8 @@ START_TEST(initcachevalues_does_not_init_without_database)
 
 	ret = initcachevalues(&s, &s.dcache);
 	ck_assert_int_eq(ret, 0);
+
+	destroystate(&s);
 }
 END_TEST
 
@@ -815,6 +829,8 @@ START_TEST(initcachevalues_does_init)
 
 	ret = db_close();
 	ck_assert_int_eq(ret, 1);
+
+	destroystate(&s);
 }
 END_TEST
 
@@ -887,6 +903,8 @@ START_TEST(waittimesync_does_not_wait_with_new_interfaces)
 
 	ret = db_close();
 	ck_assert_int_eq(ret, 1);
+
+	destroystate(&s);
 }
 END_TEST
 
@@ -921,6 +939,8 @@ START_TEST(waittimesync_knows_when_to_wait)
 
 	ret = db_close();
 	ck_assert_int_eq(ret, 1);
+
+	destroystate(&s);
 }
 END_TEST
 
@@ -955,6 +975,8 @@ START_TEST(waittimesync_knows_when_to_give_up)
 
 	ret = db_close();
 	ck_assert_int_eq(ret, 1);
+
+	destroystate(&s);
 }
 END_TEST
 
@@ -1159,6 +1181,8 @@ START_TEST(cleanremovedinterfaces_allows_interfaces_to_be_removed)
 
 	ret = db_close();
 	ck_assert_int_eq(ret, 1);
+
+	destroystate(&s);
 }
 END_TEST
 
@@ -1185,6 +1209,8 @@ START_TEST(processifinfo_syncs_when_needed)
 	ck_assert_int_eq(s.dcache->syncneeded, 0);
 	ck_assert_int_eq(s.dcache->currx, 11);
 	ck_assert_int_eq(s.dcache->curtx, 22);
+
+	destroystate(&s);
 }
 END_TEST
 
@@ -1213,6 +1239,8 @@ START_TEST(processifinfo_skips_update_if_timestamps_make_no_sense)
 	ck_assert_int_eq(s.dcache->syncneeded, 0);
 	ck_assert_int_eq(s.dcache->currx, 0);
 	ck_assert_int_eq(s.dcache->curtx, 0);
+
+	destroystate(&s);
 }
 END_TEST
 
@@ -1266,6 +1294,8 @@ START_TEST(processifinfo_syncs_if_timestamps_match)
 	ck_assert_int_eq(s.dcache->currx, 11);
 	ck_assert_int_eq(s.dcache->curtx, 22);
 	ck_assert_ptr_eq(s.dcache->log, NULL);
+
+	destroystate(&s);
 }
 END_TEST
 
@@ -1300,6 +1330,8 @@ START_TEST(processifinfo_adds_traffic)
 	ck_assert_int_eq(s.dcache->currx, 11);
 	ck_assert_int_eq(s.dcache->curtx, 22);
 	ck_assert_ptr_ne(s.dcache->log, NULL);
+
+	destroystate(&s);
 }
 END_TEST
 
@@ -1335,6 +1367,8 @@ START_TEST(processifinfo_does_not_add_traffic_when_over_limit)
 	ck_assert_int_eq(s.dcache->currx, 1111111);
 	ck_assert_int_eq(s.dcache->curtx, 2222222);
 	ck_assert_ptr_eq(s.dcache->log, NULL);
+
+	destroystate(&s);
 }
 END_TEST
 
@@ -1372,6 +1406,8 @@ START_TEST(processifinfo_adds_zero_traffic_when_over_limit)
 	ck_assert_ptr_ne(s.dcache->log, NULL);
 	ck_assert_int_eq(s.dcache->log->rx, 0);
 	ck_assert_int_eq(s.dcache->log->tx, 0);
+
+	destroystate(&s);
 }
 END_TEST
 
@@ -1410,6 +1446,8 @@ START_TEST(datacache_status_can_show_limits)
 	ck_assert_int_eq(ret, 1);
 
 	datacache_status(&dcache);
+
+	datacache_clear(&dcache);
 }
 END_TEST
 
@@ -1431,6 +1469,8 @@ START_TEST(datacache_status_has_no_issues_with_large_number_of_interfaces)
 	}
 
 	datacache_status(&dcache);
+
+	datacache_clear(&dcache);
 }
 END_TEST
 


### PR DESCRIPTION
Fix one off-by-one-read and silence multiple findings by running the testsuite with clang's sanitizers.

Reproduce:
```
CC="clang -Wall -Wextra -O1 -g -fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined -fsanitize=nullability -fsanitize=implicit-conversion -fsanitize=integer" ./configure
make check
```

Edit: Also add a sanitizer build for travis-ci