### PR TITLE
Makefile.am: fix build failure due to double installation of programs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -143,7 +143,7 @@ release: distcheck
 	rm -fr $(PACKAGE_NAME)-$(PACKAGE_VERSION)
 	ls -l $(PACKAGE_NAME)-$(PACKAGE_VERSION).tar.gz
 
-install-data-hook: install-exec
+install-data-hook:
 	if [ -f $(DESTDIR)$(man1dir)/vnstatd.1 ]; then rm -f $(DESTDIR)$(man1dir)/vnstatd.1; fi
 	$(MKDIR_P) $(DESTDIR)$(sysconfdir)
 if IS_CROSSCOMPILED


### PR DESCRIPTION
install-data-hook should not depend on install-exec otherwise build
could fail due to the double installation of vnstati:

PATH="/data/buildroot/buildroot-test/instance-0/output/host/bin:/data/buildroot/buildroot-test/instance-0/output/host/sbin:/data/buildroot/buildroot-test/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl"  /usr/bin/make -j12 DESTDIR=/data/buildroot/buildroot-test/instance-0/output/target install -C /data/buildroot/buildroot-test/instance-0/output/build/vnstat-2.4/
make[1]: Entering directory '/data/buildroot/buildroot-test/instance-0/output/build/vnstat-2.4'
Making install in .
make[2]: Entering directory '/data/buildroot/buildroot-test/instance-0/output/build/vnstat-2.4'
make[3]: Entering directory '/data/buildroot/buildroot-test/instance-0/output/build/vnstat-2.4'
 /usr/bin/mkdir -p '/data/buildroot/buildroot-test/instance-0/output/target/usr/bin'
 /usr/bin/mkdir -p '/data/buildroot/buildroot-test/instance-0/output/target/usr/sbin'
 /usr/bin/mkdir -p '/data/buildroot/buildroot-test/instance-0/output/target/usr/share/man/man1'
 /usr/bin/mkdir -p '/data/buildroot/buildroot-test/instance-0/output/target/usr/share/man/man5'
 /usr/bin/mkdir -p '/data/buildroot/buildroot-test/instance-0/output/target/usr/share/man/man8'
  /usr/bin/install -c vnstat vnstati '/data/buildroot/buildroot-test/instance-0/output/target/usr/bin'
  /usr/bin/install -c vnstatd '/data/buildroot/buildroot-test/instance-0/output/target/usr/sbin'
 /usr/bin/install -c -m 644 man/vnstat.1 man/vnstati.1 '/data/buildroot/buildroot-test/instance-0/output/target/usr/share/man/man1'
 /usr/bin/install -c -m 644 man/vnstat.conf.5 '/data/buildroot/buildroot-test/instance-0/output/target/usr/share/man/man5'
 /usr/bin/install -c -m 644 man/vnstatd.8 '/data/buildroot/buildroot-test/instance-0/output/target/usr/share/man/man8'
/usr/bin/make  install-data-hook
make[4]: Entering directory '/data/buildroot/buildroot-test/instance-0/output/build/vnstat-2.4'
Making install-exec in .
make[5]: Entering directory '/data/buildroot/buildroot-test/instance-0/output/build/vnstat-2.4'
 /usr/bin/mkdir -p '/data/buildroot/buildroot-test/instance-0/output/target/usr/bin'
 /usr/bin/mkdir -p '/data/buildroot/buildroot-test/instance-0/output/target/usr/sbin'
  /usr/bin/install -c vnstat vnstati '/data/buildroot/buildroot-test/instance-0/output/target/usr/bin'
  /usr/bin/install -c vnstatd '/data/buildroot/buildroot-test/instance-0/output/target/usr/sbin'
/usr/bin/install: cannot create regular file '/data/buildroot/buildroot-test/instance-0/output/target/usr/bin/vnstati': File exists

Fixes:
 - http://autobuild.buildroot.org/results/3aefa8d63f710b71720fc114450110d2f885820b

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>