### PR TITLE
Check local

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -179,4 +179,4 @@ clean-local:
 	-rm -fr coverage *.lcov *.gz test*.log test*.xml src/*.gc* tests/*.gc* *.old *.new *check.png INSTALL INSTALL_BSD UPGRADE UNINSTALL
 
 check-local: check-TESTS
-	-tail -n 2 test.log
+	tail -n 2 test.log

--- a/Makefile.am
+++ b/Makefile.am
@@ -178,5 +178,5 @@ uninstall-hook:
 clean-local:
 	-rm -fr coverage *.lcov *.gz test*.log test*.xml src/*.gc* tests/*.gc* *.old *.new *check.png INSTALL INSTALL_BSD UPGRADE UNINSTALL
 
-check-local:
+check-local: check-TESTS
 	-tail -n 2 test.log


### PR DESCRIPTION
When executing `make check` in parallel, check-local might be executed before check-TESTS (the normal test suite) has finished.
That makes the printing of test.log useless.

Humans might be able to always run `make check` serially, but e.g. during a Debian package build every step runs parallelly.

Also fail check-local, if tailing test.log fails.

**Note**: this requires a regeneration of the autoconfig configuration files to take effect

Example output:

    $ make -j check
    Making check in .
    make[1]: Entering directory '/home/christian/Coding/workspaces/smartgit/vnstat'
    make  check_vnstat
    make[2]: Entering directory '/home/christian/Coding/workspaces/smartgit/vnstat'
    make[2]: Leaving directory '/home/christian/Coding/workspaces/smartgit/vnstat'
    make  check-TESTS check-local
    make[2]: Entering directory '/home/christian/Coding/workspaces/smartgit/vnstat'
    tail -n 2 test.log
    tail: cannot open 'test.log' for reading: No such file or directory
    make[2]: [Makefile:2391: check-local] Error 1 (ignored)
    make[3]: Entering directory '/home/christian/Coding/workspaces/smartgit/vnstat'
    PASS: check_vnstat
    ============================================================================
    Testsuite summary for vnstat 2.5_beta1
    ============================================================================
    # TOTAL: 1
    # PASS:  1
    # SKIP:  0
    # XFAIL: 0
    # FAIL:  0
    # XPASS: 0
    # ERROR: 0
    ============================================================================