### PR TITLE
Error early on non Linux and BSD like systems

### DIFF
--- a/src/ifinfo.c
+++ b/src/ifinfo.c
@@ -110,6 +110,8 @@ int getiflist(iflist **ifl, const int getspeed, const int validate)
 	return getiflist_linux(ifl, getspeed, validate);
 #elif defined(BSD_VNSTAT)
 	return getiflist_bsd(ifl, getspeed, validate);
+#else
+#error vnStat only supports Linux and BSD like systems
 #endif
 }
 


### PR DESCRIPTION
E.g. vnStat compiles on hurd, but the testsuite fails ultimately