### PR TITLE
Check for memory allocation failure to prevent null-dereference

### DIFF
--- a/src/dbsql.c
+++ b/src/dbsql.c
@@ -1379,6 +1379,9 @@ char *getifaceinquery(const char *input)
 	/* each interface requires two quotes and comma or \0 so 3 extra chars */
 	j = (unsigned int)strlen(input) + ifacecount * 3;
 	result = malloc(sizeof(char) * j);
+	if (result == NULL) {
+		return NULL;
+	}
 	memset(result, '\0', j);
 
 	result[0] = '"';


### PR DESCRIPTION
Found by GCC analyzer