### PR TITLE
vnstat.conf.5: use single closing '

### DIFF
--- a/man/vnstat.conf.5
+++ b/man/vnstat.conf.5
@@ -15,7 +15,7 @@ and
 all use the same configuration file for configuration related settings.
 Some of the settings are common for all three programs. The file
 consists of keyword-argument pairs, one per line. Empty lines and
-lines starting with\ '#\' are interpreted as comments and not processed.
+lines starting with '#' are interpreted as comments and not processed.
 Arguments may optionally be enclosed in double quotes (") in order
 to represent arguments containing spaces. Arguments can be padded
 with spaces or tabulator characters. A hardcoded default value


### PR DESCRIPTION
Currently the man page shows
```
'#`
```
, let show it
```
'#'
```
.

Found by Lintian (acute-accent-in-manual-page)

    This manual page uses the \' groff sequence. Usually, the intent to
    generate an apostrophe, but that sequence actually renders as a an acute
    accent.

    For an apostrophe or a single closing quote, use plain '. For single
    opening quote, i.e. a straight downward line ' like the one used in
    shell commands, use &#92;(aq.