### PR TITLE
rename: Correctly print existing interface

### DIFF
--- a/src/vnstat_func.c
+++ b/src/vnstat_func.c
@@ -547,7 +547,7 @@ void handlerenameinterface(PARAMS *p)
 	}
 
 	if (db_getinterfacecountbyname(p->newifname)) {
-		printf("Error: Interface \"%s\" already exists in database.\n", p->interface);
+		printf("Error: Interface \"%s\" already exists in database.\n", p->newifname);
 		exit(EXIT_FAILURE);
 	}
 


### PR DESCRIPTION
I was renaming my interface in vnstat from `enp8s0` to `enp9s0` as my network adapter changed names and noticed the wrong interface was being printed here.

It's supposed to print the newer interface's name - as it's an error regarding it already existing on the database.