### PR TITLE
Document that the pidfile is only created when running with --daemon

### DIFF
--- a/man/vnstat.conf.5
+++ b/man/vnstat.conf.5
@@ -301,7 +301,8 @@ interfaces are offline. Value range:
 
 .TP
 .B PidFile
-Specify pid file path and name to be used.
+Specify pid file path and name to be used. The file is created only if the
+daemon is started as a background process.
 
 .TP
 .B PollInterval

--- a/man/vnstatd.8
+++ b/man/vnstatd.8
@@ -114,7 +114,10 @@ Write the process id to
 and use it for locking so that another instance of the daemon cannot
 be started if the same
 .I file
-is specified.
+is specified. This option has no effect if combined with
+.B -n
+or
+.BR --nodaemon .
 
 .TP
 .B "-s, --sync"
@@ -240,8 +243,9 @@ is specified in the config file.
 
 .TP
 .I /var/run/vnstat/vnstat.pid
-File used for storing the process id if no other file is specified in the
-configuration file or using the command line parameter.
+File used for storing the process id when running as a background process and
+if no other file is specified in the configuration file or using the command
+line parameter.
 
 .SH RESTRICTIONS
 

--- a/src/vnstatd.c
+++ b/src/vnstatd.c
@@ -293,6 +293,10 @@ void parseargs(DSTATE *s, int argc, char **argv)
 			printf("vnStat daemon %s by Teemu Toivola <tst at iki dot fi>\n", getversion());
 			exit(EXIT_SUCCESS);
 		} else if ((strcmp(argv[currentarg], "-p") == 0) || (strcmp(argv[currentarg], "--pidfile") == 0)) {
+			if (!s->rundaemon) {
+				printf("Error: --pidfile can only be used together with --daemon\n");
+				exit(EXIT_FAILURE);
+			}
 			if (currentarg + 1 < argc) {
 				strncpy_nt(cfg.pidfile, argv[currentarg + 1], 512);
 				cfg.pidfile[511] = '\0';


### PR DESCRIPTION
`man 5 vnstat.conf` lists under `CreateDirs`
>The PidFile directory will be created only if the daemon is started as a background process.

It would be nice to also mention that this file is not used at:
- [x] `PidFile` entry in `man 5 vnstat.conf` 
- [x] `--pidfile` command line option documented at `man 8 vnstatd`
- [x] in the output given by `vnstatd --help`
- [x] additionally, mentioned it also at the point which describes the file in `man 8 vnstatd`

The second commit will throw an error when the option is used at the wrong time, to warn users that it wouldn't do what they expect.

But the real question is rather: Should it behave the way it currently does? Maybe it should always create the lockfile?

With the systemd service, `--nodaemon` is used to avoid the process forking away. So that the stdour/stderr will go into the journal of that unit.
