### PR TITLE
Do not cap update interval on 64-bit linux counters

### DIFF
--- a/src/cfg.c
+++ b/src/cfg.c
@@ -172,7 +172,6 @@ void validateint(const char *cfgname, int32_t *cfgptr, const int32_t defaultvalu
 
 void validatecfg(void)
 {
-	uint32_t rolloversecs;
 	const char *invalidvalue = "Invalid value for";
 	const char *resettingto = "resetting to";
 	const char *noslashstart = "doesn't start with \"/\", resetting to default.";
@@ -274,7 +273,7 @@ void validatecfg(void)
 	/* 1.02 is the same 2% safety buffer as used in processifinfo() in daemon.c */
 	/* noexit check results in warning being shown only when the daemon is started */
 	if (noexit && cfg.maxbw > 0) {
-		rolloversecs = (uint32_t)((float)MAX32 / ((float)cfg.maxbw * 1024 * 1024 * (float)1.02 / 8));
+		uint32_t rolloversecs = (uint32_t)((float)MAX32 / ((float)cfg.maxbw * 1024 * 1024 * (float)1.02 / 8));
 		if (rolloversecs <= (uint32_t)cfg.updateinterval) {
 			cfg.updateinterval = UPDATEINTERVAL;
 			if (rolloversecs <= (uint32_t)cfg.updateinterval) {

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -269,6 +269,7 @@ void validatecfg(void)
 		printe(PT_Config);
 	}
 
+#if !( defined(__linux__) && HAVE_DECL_IFLA_STATS64 )
 	/* enforce update interval to be short enough that 32-bit interface counter rollover can be detected */
 	/* 1.02 is the same 2% safety buffer as used in processifinfo() in daemon.c */
 	/* noexit check results in warning being shown only when the daemon is started */
@@ -283,6 +284,7 @@ void validatecfg(void)
 			printe(PT_Config);
 		}
 	}
+#endif
 }
 
 void defaultcfg(void)


### PR DESCRIPTION
On a 64-bit Linux system, with
```
UpdateInterval 60
```
I get an error:
```
Config: UpdateInterval has been reset to 20 seconds in order to ensure correct counter rollover detection at 1000 Mbit.
```

This PR allows 64-bit linux systems to use larger `UpdateInterval` values.