### PR TITLE
Use correct format length specifiers for 32-bit systems

### DIFF
--- a/src/image.c
+++ b/src/image.c
@@ -970,13 +970,13 @@ int drawfiveminutes(IMAGECONTENT *ic, const int xpos, const int ypos, const int 
 	}
 
 	if (debug) {
-		printf("maxrx: %lu\n", datainfo.maxrx);
-		printf("maxtx: %lu\n", datainfo.maxtx);
+		printf("maxrx: %" PRIu64 "\n", datainfo.maxrx);
+		printf("maxtx: %" PRIu64 "\n", datainfo.maxtx);
 		printf("rxh: %d     txh: %d\n", rxh, txh);
-		printf("max divided: %lu\n", max);
-		printf("scaleunit:   %lu\nstep: %d\n", scaleunit, step);
+		printf("max divided: %" PRIu64 "\n", max);
+		printf("scaleunit:   %" PRIu64 "\nstep: %d\n", scaleunit, step);
 		printf("pixels per step: %d\n", s);
-		printf("mintime: %lu\nmaxtime: %lu\n", (uint64_t)datainfo.mintime, (uint64_t)datainfo.maxtime);
+		printf("mintime: %" PRIu64 "\nmaxtime: %" PRIu64 "\n", (uint64_t)datainfo.mintime, (uint64_t)datainfo.maxtime);
 		printf("count: %u\n", datainfo.count);
 	}
 

--- a/src/image_support.c
+++ b/src/image_support.c
@@ -90,7 +90,7 @@ void colorinitcheck(const char *color, const int value, const char *cfgtext, con
 	}
 }
 
-void layoutinit(IMAGECONTENT *ic, char *title, const int width, const int height)
+void layoutinit(IMAGECONTENT *ic, const char *title, const int width, const int height)
 {
 	struct tm *d;
 	char datestring[64], buffer[512];

--- a/src/image_support.h
+++ b/src/image_support.h
@@ -5,7 +5,7 @@
 
 void imageinit(IMAGECONTENT *ic, const int width, const int height);
 void colorinitcheck(const char *color, const int value, const char *cfgtext, const int *rgb);
-void layoutinit(IMAGECONTENT *ic, char *title, const int width, const int height);
+void layoutinit(IMAGECONTENT *ic, const char *title, const int width, const int height);
 void drawlegend(IMAGECONTENT *ic, const int x, const int y, const short israte);
 void drawbar(IMAGECONTENT *ic, const int x, const int y, const int len, const uint64_t rx, const uint64_t tx, const uint64_t max, const short isestimate);
 void drawpoles(IMAGECONTENT *ic, const int x, const int y, const int len, const uint64_t rx, const uint64_t tx, const uint64_t max);


### PR DESCRIPTION
```
src/image.c: In function 'drawfiveminutes':
src/image.c:973:20: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'uint64_t' {aka 'long long unsigned int'} [-Wformat=]
  973 |   printf("maxrx: %lu\n", datainfo.maxrx);
      |                  ~~^     ~~~~~~~~~~~~~~
      |                    |             |
      |                    |             uint64_t {aka long long unsigned int}
      |                    long unsigned int
      |                  %llu
src/image.c:974:20: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'uint64_t' {aka 'long long unsigned int'} [-Wformat=]
  974 |   printf("maxtx: %lu\n", datainfo.maxtx);
      |                  ~~^     ~~~~~~~~~~~~~~
      |                    |             |
      |                    |             uint64_t {aka long long unsigned int}
      |                    long unsigned int
      |                  %llu
src/image.c:976:26: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'uint64_t' {aka 'long long unsigned int'} [-Wformat=]
  976 |   printf("max divided: %lu\n", max);
      |                        ~~^     ~~~
      |                          |     |
      |                          |     uint64_t {aka long long unsigned int}
      |                          long unsigned int
      |                        %llu
src/image.c:977:26: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'uint64_t' {aka 'long long unsigned int'} [-Wformat=]
  977 |   printf("scaleunit:   %lu\nstep: %d\n", scaleunit, step);
      |                        ~~^               ~~~~~~~~~
      |                          |               |
      |                          |               uint64_t {aka long long unsigned int}
      |                          long unsigned int
      |                        %llu
src/image.c:979:22: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'long long unsigned int' [-Wformat=]
  979 |   printf("mintime: %lu\nmaxtime: %lu\n", (uint64_t)datainfo.mintime, (uint64_t)datainfo.maxtime);
      |                    ~~^                   ~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                      |                   |
      |                      long unsigned int   long long unsigned int
      |                    %llu
src/image.c:979:36: warning: format '%lu' expects argument of type 'long unsigned int', but argument 3 has type 'long long unsigned int' [-Wformat=]
  979 |   printf("mintime: %lu\nmaxtime: %lu\n", (uint64_t)datainfo.mintime, (uint64_t)datainfo.maxtime);
      |                                  ~~^                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                    |                                 |
      |                                    long unsigned int                 long long unsigned int
      |                                  %llu
```