### PR TITLE
Mark input argument to hextorgb const

### DIFF
--- a/src/image_support.c
+++ b/src/image_support.c
@@ -362,7 +362,7 @@ void drawarrowright(IMAGECONTENT *ic, const int x, const int y)
 	gdImageLine(ic->im, x + 1, y, x - 1, y, ic->ctext);
 }
 
-void hextorgb(char *input, int *rgb)
+void hextorgb(const char *input, int *rgb)
 {
 	int offset;
 	char hex[3], dec[4];

--- a/src/image_support.h
+++ b/src/image_support.h
@@ -15,7 +15,7 @@ void drawdonut_libgd_native(IMAGECONTENT *ic, const int x, const int y, const fl
 void drawpole(IMAGECONTENT *ic, const int x, const int y, const int length, const int direction, const int maincolor);
 void drawarrowup(IMAGECONTENT *ic, const int x, const int y);
 void drawarrowright(IMAGECONTENT *ic, const int x, const int y);
-void hextorgb(char *input, int *rgb);
+void hextorgb(const char *input, int *rgb);
 void modcolor(int *rgb, const int offset, const int force);
 char *getimagevalue(const uint64_t b, const int len, const int rate);
 char *getimagescale(const uint64_t b, const int rate);


### PR DESCRIPTION
    tests/image_tests.c: In function ‘hextorgb_can_convert_fn’:
    tests/image_tests.c:738:18: warning: passing argument 1 of ‘hextorgb’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
      738 |         hextorgb(000000, rgb);
          |                  ^~~~~~~~
    In file included from tests/image_tests.c:7:
    ./src/image_support.h:18:21: note: expected ‘char *’ but argument is of type ‘const char *’
       18 | void hextorgb(char *input, int *rgb);
          |               ~~~~~~^~~~~