### PR TITLE
handle DT_UNKNOWN type entries in remove_directory

### DIFF
--- a/tests/vnstat_tests.c
+++ b/tests/vnstat_tests.c
@@ -213,6 +213,23 @@ int remove_directory(const char *directory)
 					return 0;
 				}
 				break;
+			case DT_UNKNOWN:
+				if (strcmp(di->d_name, ".") == 0 || strcmp(di->d_name, "..") == 0) {
+					continue;
+				}
+				snprintf(entryname, 512, "%s/%s", directory, di->d_name);
+				if (unlink(entryname) != 0) {
+					if (errno == EISDIR) {
+						if (!remove_directory(entryname)) {
+							closedir(dir);
+							return 0;
+						}
+					} else {
+						closedir(dir);
+						return 0;
+					}
+				}
+				break;
 			default:
 				continue;
 		}


### PR DESCRIPTION
readdir(3) may not determine the type of the returned entry, quoting man:readdir(3):

    Currently, only some filesystems (among them: Btrfs, ext2, ext3, and
    ext4) have full support for returning the file type in d_type. All
    applications must properly handle a return of DT_UNKNOWN.

This happens for example in the Debian salsa-ci for reproducible builds.