### PR TITLE
man: run the tbl preprocessor to silence groff warning

### DIFF
--- a/man/vnstat.1
+++ b/man/vnstat.1
@@ -1,3 +1,4 @@
+'\" t
 .TH VNSTAT 1 "AUGUST 2023" "version 2.11" "User Manuals"
 .SH NAME
 vnstat \- a console-based network traffic monitor

--- a/man/vnstatd.8
+++ b/man/vnstatd.8
@@ -1,3 +1,4 @@
+'\" t
 .TH VNSTATD 8 "AUGUST 2023" "version 2.11" "User Manuals"
 .SH NAME
 vnstatd \- daemon based database updating for vnStat


### PR DESCRIPTION
Reported by Lintian:

    $ LC_ALL=C.UTF-8 MANROFFSEQ='' MANWIDTH=80 man --warnings -E UTF-8 -l -Tutf8 -Z ./man/vnstat.1 >/dev/null
    an.tmac:<standard input>:600: warning: tbl preprocessor failed, or it or soelim was not run; table(s) likely not rendered (TE macro called with TW register undefined)

See https://lists.debian.org/debian-devel/2023/08/msg00220.html